### PR TITLE
Add Jest setup and basic camelCase test

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: ['next/babel']
+};

--- a/helpers/__tests__/camelCase.test.js
+++ b/helpers/__tests__/camelCase.test.js
@@ -1,0 +1,5 @@
+import { camelSentence } from '../camelCase';
+
+test('camelSentence transforms hello world', () => {
+  expect(camelSentence('hello world')).toBe('helloWorld');
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.js$': 'babel-jest'
+  }
+};

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "test": "jest"
   },
   "dependencies": {
     "@contentful/rich-text-react-renderer": "^14.1.3",
@@ -31,6 +32,8 @@
     "autoprefixer": "^10.2.5",
     "postcss": "^8.2.14",
     "tailwindcss": "^2.1.2",
-    "tailwindcss-debug-screens": "^2.0.0"
+    "tailwindcss-debug-screens": "^2.0.0",
+    "jest": "^27.0.0",
+    "babel-jest": "^27.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- add Jest config with `babel-jest`
- configure Babel preset for tests
- add `test` script and dev dependencies
- create initial camelSentence test

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849b7784c04832296f0a3c87446b92f